### PR TITLE
Add bypass perm

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
@@ -55,7 +55,7 @@ public class BorderCheckTask implements Runnable
 			return null;
 
 		// if player is in bypass list (from bypass command), allow them beyond border; also ignore players currently being handled already
-		if (Config.isPlayerBypassing(player.getUniqueId()) || handlingPlayers.contains(player.getName().toLowerCase()))
+		if (Config.isPlayerBypassing(player.getUniqueId()) || player.hasPermission("worldborder.allowbypass") || handlingPlayers.contains(player.getName().toLowerCase()))
 			return null;
 
 		// tag this player as being handled so we can't get stuck in a loop due to Bukkit currently sometimes repeatedly providing incorrect location through teleport event

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -160,3 +160,6 @@ permissions:
   worldborder.wshape:
     description: Can set an overriding border shape for a single world
     default: op
+  worldborder.allowbypass:
+    description: Can allow a player to bypass the world border
+    default: false


### PR DESCRIPTION
While I was making the other PR I thought I might as well do this for @Prof-Bloodstone. Tested and works as expected. The perm is `worldborder.allowbypass` since `worldborder.bypass` is already used for the command. Open to alternative naming suggestions.

Closes #8